### PR TITLE
Delete status code fix

### DIFF
--- a/lib/controllers/meals.js
+++ b/lib/controllers/meals.js
@@ -58,11 +58,7 @@ const deleteMealFood = (request, response, next) => {
   var id = request.params.id
   Meals.deleteFood(mealId, id)
   .then(function(data) {
-    if(!data.rows[0]) {
-      response.sendStatus(404)
-    } else{
-      response.json(data.rows)
-    }
+    response.sendStatus(202)
   })
 }
 

--- a/lib/controllers/meals.js
+++ b/lib/controllers/meals.js
@@ -1,8 +1,3 @@
-const environment = process.env.NODE_ENV || 'development';    // if something else isn't setting ENV, use development
-const configuration = require('../../knexfile')[environment];    // require environment's settings from knexfile
-const database = require('knex')(configuration);              // connect to DB via knex using env's settings
-var express = require('express');
-var app = express();
 var bodyParser = require('body-parser');
 const Meals = require('../models/meal')
 


### PR DESCRIPTION
Fixed the status sent back by the delete request to a 202 rather than a 404, a catch block might still be appropriate for any errors encountered. This cleared up the issue of the meal foods delete button not immediately rendering on the front-end.